### PR TITLE
Add Kamon support to generated processors

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ import sbtassembly.Plugin._
 import AssemblyKeys._
 
 object Scrooge extends Build {
-  val libVersion = "3.17.0-VDNA-4"
+  val libVersion = "3.17.0-VDNA-5"
   val utilVersion = "6.22.0"
   val finagleVersion = "6.22.0"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -206,7 +206,8 @@ object Scrooge extends Build {
     name := "scrooge-scalaz",
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.9.3-VDNA-3",
-      "org.scalaz" %% "scalaz-concurrent" % "7.1.0"
+      "org.scalaz" %% "scalaz-concurrent" % "7.1.0",
+      "io.kamon" %% "kamon-core" % "0.3.5"
     ),
     crossScalaVersions += "2.11.2"
   ).dependsOn(scroogeCore)

--- a/scrooge-generator/src/main/resources/scalagen/scalazProcessor.scala
+++ b/scrooge-generator/src/main/resources/scalagen/scalazProcessor.scala
@@ -6,10 +6,11 @@ import com.twitter.scrooge.AsyncThriftFunction
 import com.twitter.scrooge.AsyncThriftProcessor
 import com.twitter.scrooge.ThriftStruct
 import scalaz.concurrent.Task
+import akka.actor.ActorSystem
 
 {{docstring}}
 @javax.annotation.Generated(value = Array("com.twitter.scrooge.Compiler"), date = "{{date}}")
-class {{ServiceName}}$ScalazProcessor(iface: {{ServiceName}}[Task]) extends AsyncThriftProcessor[{{ServiceName}}[Task]](iface) {
+class {{ServiceName}}$ScalazProcessor(iface: {{ServiceName}}[Task])(implicit as: ActorSystem) extends AsyncThriftProcessor[{{ServiceName}}[Task]](iface) {
 
   protected val processMap = (
 {{#syncFunctions}}

--- a/scrooge-maven-plugin/pom.xml
+++ b/scrooge-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>scrooge-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>scrooge-maven-plugin</name>
-  <version>3.17.0-VDNA-4</version>
+  <version>3.17.0-VDNA-5</version>
   <prerequisites>
     <maven>2.0.6</maven>
   </prerequisites>
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-generator_2.10</artifactId>
-      <version>3.17.0-VDNA-4</version>
+      <version>3.17.0-VDNA-5</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/scrooge-scalaz/src/main/scala/com/twitter/scrooge/ScalazThriftFunction.scala
+++ b/scrooge-scalaz/src/main/scala/com/twitter/scrooge/ScalazThriftFunction.scala
@@ -10,12 +10,13 @@ import scalaz.concurrent.Task
 import scalaz._
 import scalaz.Scalaz._
 import org.apache.thrift.server.AbstractNonblockingServer
-import com.twitter.scrooge.AsyncThriftFunction
+import scala.reflect.ClassTag
 
 /**
  * TODO: common code between this and ThriftFunction could be factored out
  */
-abstract class ScalazThriftFunction[I, T <: ThriftStruct](methodName: String) extends AsyncThriftFunction[I] {
+abstract class ScalazThriftFunction[I, T <: ThriftStruct](methodName: String)(implicit ct: ClassTag[I]) extends AsyncThriftFunction[I] {
+  val traceName = s"${ct.getClass.getSimpleName}.$methodName"
 
   protected val oneWay = false
 


### PR DESCRIPTION
This means we'll automatically get performance stats for thrift calls in newrelic/graphite.
